### PR TITLE
Update allowed origins in cors.php

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*.geosm.org', '*.position.cm', '*.francophonie.org', 'http://localhost:4200'],
+    'allowed_origins' => ['*.geosm.org', '*.position.cm', '*.francophonie.org', '*.sdgmapping.org', 'http://localhost:4200'],
 
     'allowed_origins_patterns' => [],
 


### PR DESCRIPTION
This pull request updates the list of allowed origins in the cors.php file. The new list includes '*.sdgmapping.org' in addition to the existing origins.