### PR TITLE
Add https://sdgmapping.org to allowed_origins in cors.php

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*.geosm.org', '*.position.cm', '*.francophonie.org', '*.sdgmapping.org', 'http://localhost:4200'],
+    'allowed_origins' => ['*.geosm.org', '*.position.cm', '*.francophonie.org', '*.sdgmapping.org', 'http://localhost:4200', 'https://sdgmapping.org'],
 
     'allowed_origins_patterns' => [],
 


### PR DESCRIPTION
This pull request adds the URL https://sdgmapping.org to the 'allowed_origins' array in the cors.php file. This change allows requests from the sdgmapping.org domain to be accepted by the server.