### PR TITLE
Add Haiti with both name variants to country selections

### DIFF
--- a/app/Filament/Resources/OscResource.php
+++ b/app/Filament/Resources/OscResource.php
@@ -188,7 +188,7 @@ class OscResource extends Resource
             6 => ['pays' => ['Senegal', 'Sénégal']],
             7 => ['pays' => ['Côte d\'ivoire', 'Côte d\'Ivoire', 'Cote d\'ivoire', 'Cote d\'Ivoire']],
             8 => ['pays' => 'Tanzania'],
-            9 => ['pays' => 'Haiti'],
+            9 => ['pays' => 'Haiti', 'Haïti'],
         ];
 
         $userRole = auth()->user()->role;
@@ -255,7 +255,7 @@ class OscResource extends Resource
 
         if (auth()->user()->role == 9) {
 
-            $country = parent::getEloquentQuery()->where('pays', 'Haiti');
+            $country = parent::getEloquentQuery()->where('pays', 'Haiti')->orWhere('pays', 'Haïti');
             return $country->count();
         }
 


### PR DESCRIPTION
Include 'Haiti' and 'Haïti' in country selections and update the query to accommodate both variants.